### PR TITLE
kmod::load - load modules at boot time

### DIFF
--- a/manifests/generic.pp
+++ b/manifests/generic.pp
@@ -33,8 +33,9 @@ define kmod::generic(
   case $ensure {
     present: {
       if $type == 'install' {
-        exec {"modprobe ${module}":
-          unless => "egrep -q '^${module} ' /proc/modules",
+        kmod::load { $module:
+          ensure => present,
+          after  => Augeas["${type} module ${module}"],
         }
       }
 
@@ -64,8 +65,8 @@ define kmod::generic(
     }
 
     absent: {
-      exec {"modprobe -r ${module}":
-        onlyif => "egrep -q '^${module} ' /proc/modules",
+      kmod::load { $module:
+        ensure => absent,
       }
 
       augeas {"remove module ${module}":

--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -1,0 +1,32 @@
+define kmod::load (
+  $ensure='present'
+) {
+
+  case $ensure {
+    'present': {
+      exec { "modprobe ${name}":
+        unless => "egrep -q '^${name} ' /proc/modules",
+      }
+
+      augeas { "load module ${name} at boot":
+        incl    => '/etc/modules',
+        lens    => 'Modules.lns',
+        changes => "ins '${name}' after *[last()]",
+        onlyif  => "match '${name}' size == 0",
+      }
+    }
+
+    'absent': {
+      exec { "modprobe -r ${name}":
+        onlyif => "egrep -q '^${name} ' /proc/modules",
+      }
+
+      augeas { "don't load module ${name} at boot":
+        incl    => '/etc/modules',
+        lens    => 'Modules.lns',
+        changes => "rm '${name}'",
+        onlyif  => "match '${name}' size > 0",
+      }
+    }
+  }
+}


### PR DESCRIPTION
Previously we had no way to ensure kernel modules where loaded at boot.
This patch enables this.
