### PR TITLE
kmod::load - make definition work for redhat

### DIFF
--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -39,9 +39,20 @@ define kmod::load(
     default: { err ( "unknown ensure value ${ensure}" ) }
   }
 
-  augeas {"Manage ${name} in ${file}":
-    incl    => $file,
-    lens    => 'Modules.lns',
-    changes => $changes,
+  case $::osfamily {
+    'Debian': {
+      augeas {"Manage ${name} in ${file}":
+        incl    => $file,
+        lens    => 'Modules.lns',
+        changes => $changes,
+      }
+    }
+    'RedHat': {
+      file { "/etc/sysconfig/modules/${name}.modules":
+        ensure  => $ensure,
+        mode    => 0755,
+        content => template('kmod/redhat.modprobe.erb'),
+      }
+    }
   }
 }

--- a/templates/redhat.modprobe.erb
+++ b/templates/redhat.modprobe.erb
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# file managed by puppet
+
+exec /sbin/modprobe <%= name %> > /dev/null 2>&1


### PR DESCRIPTION
/etc/modules is apparently specific to debian. Redhat loads modules at
boot time using small shell scripts in /etc/sysconfig/modules/
