### PR TITLE
Add kmod::alias define for module aliases.

### DIFF
--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -1,0 +1,51 @@
+# = Define: kmod::alias
+#
+# == Example
+#
+#     kmod::alias { 'bond0':
+#       alias => 'bonding',
+#     }
+#
+define kmod::alias(
+  $source,
+  $ensure = 'present',
+  $file   = '/etc/modprobe.d/aliases.conf',
+) {
+
+  include kmod
+
+  case $ensure {
+    present: {
+      $augset = [
+        "set alias[. = '${name}'] ${name}",
+        "set alias[. = '${name}']/modulename ${source}",
+      ]
+      $onlyif = "match alias[. = '${name}'] size == 0"
+
+
+      augeas { "modprobe alias ${name} ${source}":
+        incl    => $file,
+        lens    => 'Modprobe.lns',
+        changes => $augset,
+        onlyif  => $onlyif,
+        require => File[$file],
+      }
+    }
+
+    absent: {
+      kmod::load { $module:
+        ensure => $ensure,
+      }
+
+      augeas {"remove modprobe alias ${name}":
+        incl    => $file,
+        lens    => 'Modprobe.lns',
+        changes => "rm alias[. = '${name}']",
+        onlyif  => "match alias[. = '${name}'] size > 0",
+        require => File[$file],
+      }
+    }
+
+    default: { err ( "unknown ensure value ${ensure}" ) }
+  }
+}


### PR DESCRIPTION
This adds a define to add in modprobe aliases using augeas. By default it will add and remove aliases in /etc/modprobe.d/aliases.conf.
