### PR TITLE
Fix for puppet deprecation warnings

### DIFF
--- a/templates/redhat.modprobe.erb
+++ b/templates/redhat.modprobe.erb
@@ -2,4 +2,4 @@
 
 # file managed by puppet
 
-exec /sbin/modprobe <%= name %> > /dev/null 2>&1
+exec /sbin/modprobe <%= @name %> > /dev/null 2>&1


### PR DESCRIPTION
FIx deprecation warnings that come out in puppet 3.5+ from the template use
