### PR TITLE
Specify full paths to egrep and modprobe

### DIFF
--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -23,16 +23,16 @@ define kmod::load(
     present: {
       $changes = "clear '${name}'"
 
-      exec { "modprobe ${name}":
-        unless => "egrep -q '^${name} ' /proc/modules",
+      exec { "/sbin/modprobe ${name}":
+        unless => "/bin/egrep -q '^${name} ' /proc/modules",
       }
     }
 
     absent: {
       $changes = "rm '${name}'"
 
-      exec { "modprobe -r ${name}":
-        onlyif => "egrep -q '^${name} ' /proc/modules",
+      exec { "/sbin/modprobe -r ${name}":
+        onlyif => "/bin/egrep -q '^${name} ' /proc/modules",
       }
     }
 


### PR DESCRIPTION
In its current incarnation, with puppet 3.7, the module fails to perform
the expected tasks with the following error message:

Error: Failed to apply catalog: Parameter unless failed on Exec[modprobe
kvm_intel]: 'egrep -q '^kvm_intel ' /proc/modules' is not qualified and
no path was specified. Please qualify the command or specify a path. at
/opt/puppet-upstream/kmod/manifests/load.pp:28
Wrapped exception:

Error: Failed to apply catalog: Validation of Exec[modprobe kvm_intel]
failed: 'modprobe kvm_intel' is not qualified and no path was specified.
Please qualify the command or specify a path. at
/opt/puppet-upstream/kmod/manifests/load.pp:28
Wrapped exception:

The problem here appears to be the fact that the full paths to both the
modprobe and egrep binaries are not specified. Specifying them makes the
problem go away; this commit conducts the required change.
