### PR TITLE
Add a path parameter to the execs for egrep and modprobe in load.pp

### DIFF
--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -24,7 +24,9 @@ define kmod::load(
       $changes = "clear '${name}'"
 
       exec { "modprobe ${name}":
-        unless => "egrep -q '^${name} ' /proc/modules",
+        path    => "/sbin:/bin:/usr/sbin:/usr/bin",
+        command => "modprobe ${name}",
+        unless  => "egrep -q '^${name} ' /proc/modules",
       }
     }
 
@@ -32,7 +34,9 @@ define kmod::load(
       $changes = "rm '${name}'"
 
       exec { "modprobe -r ${name}":
-        onlyif => "egrep -q '^${name} ' /proc/modules",
+        path    => "/sbin:/bin:/usr/sbin:/usr/bin",
+        command => "modprobe -r ${name}",
+        onlyif  => "egrep -q '^${name} ' /proc/modules",
       }
     }
 


### PR DESCRIPTION
```
In its current incarnation, with puppet 3.7, the module fails to perform
the expected tasks with the following error message:

Error: Failed to apply catalog: Parameter unless failed on Exec[modprobe
kvm_intel]: 'egrep -q '^kvm_intel ' /proc/modules' is not qualified and
no path was specified. Please qualify the command or specify a path. at
/opt/puppet-upstream/kmod/manifests/load.pp:28

Error: Failed to apply catalog: Validation of Exec[modprobe kvm_intel]
failed: 'modprobe kvm_intel' is not qualified and no path was specified.
Please qualify the command or specify a path. at
/opt/puppet-upstream/kmod/manifests/load.pp:28

The problem here appears to be the fact that the full paths to both the
modprobe and egrep binaries are not specified. Adding the "path" param
to the exec calls resolves the issue.
```
