### PR TITLE
Drop EoL CentOS 5/6 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,8 +40,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "7",
         "8"
       ]
@@ -49,8 +47,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "7",
         "8"
       ]
@@ -58,7 +54,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "description": "Manage Linux kernel modules with Puppet",


### PR DESCRIPTION
this PR contains: https://github.com/voxpupuli/puppet-kmod/pull/65