### PR TITLE
Drop Ubuntu 12/14 support; Add 18/20 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,8 +24,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
-        "14.04"
+        "18.04",
+        "20.04"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -40,8 +40,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "7",
         "8"
       ]
@@ -49,8 +47,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "7",
         "8"
       ]
@@ -58,7 +54,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "description": "Manage Linux kernel modules with Puppet",

--- a/metadata.json
+++ b/metadata.json
@@ -17,10 +17,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
-        "7",
-        "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {


### PR DESCRIPTION
this PR contains:
* https://github.com/voxpupuli/puppet-kmod/pull/65
* https://github.com/voxpupuli/puppet-kmod/pull/66
* https://github.com/voxpupuli/puppet-kmod/pull/67