### PR TITLE
Fix file detection to gather kmod fact

### DIFF
--- a/lib/facter/kmod.rb
+++ b/lib/facter/kmod.rb
@@ -1,12 +1,12 @@
 Facter.add(:kmods) do
-  confine :kernel => :linux
+  confine kernel: :linux
 
   kmod = {}
 
   setcode do
-    if File.exists?('/sys/module')
+    if File.exist?('/sys/module')
       Dir.foreach('/sys/module') do |directory|
-        next if directory == '.' or directory == '..'
+        next if ['.', '..'].include?(directory)
 
         kmod[directory] = {
           'parameters' => {},
@@ -16,7 +16,7 @@ Facter.add(:kmods) do
         if File.directory?("/sys/module/#{directory}/parameters")
           begin
             Dir.foreach("/sys/module/#{directory}/parameters") do |param|
-              next if param == '.' or param == '..'
+              next if ['.', '..'].include?(param)
               kmod[directory]['parameters'][param] = File.read("/sys/module/#{directory}/parameters/#{param}").chomp
             end
           rescue => e
@@ -27,7 +27,7 @@ Facter.add(:kmods) do
         if File.directory?("/sys/module/#{directory}/holders")
           begin
             Dir.foreach("/sys/module/#{directory}/holders") do |used|
-              next if used == '.' or used == '..'
+              next if ['.', '..'].include?(used)
               kmod[directory]['used_by'] << used
             end
           rescue => e

--- a/lib/facter/kmod.rb
+++ b/lib/facter/kmod.rb
@@ -1,42 +1,44 @@
 Facter.add(:kmods) do
   confine :kernel => :linux
-  confine File.exists?('/sys/module')
 
   kmod = {}
 
   setcode do
-    Dir.foreach('/sys/module') do |directory|
-      next if directory == '.' or directory == '..'
+    if File.exists?('/sys/module')
+      Dir.foreach('/sys/module') do |directory|
+        next if directory == '.' or directory == '..'
 
-      kmod[directory] = {
-        'parameters' => {},
-        'used_by' => [],
-      }
+        kmod[directory] = {
+          'parameters' => {},
+          'used_by' => [],
+        }
 
-      if File.directory?("/sys/module/#{directory}/parameters")
-        begin
-          Dir.foreach("/sys/module/#{directory}/parameters") do |param|
-            next if param == '.' or param == '..'
-            kmod[directory]['parameters'][param] = File.read("/sys/module/#{directory}/parameters/#{param}").chomp
+        if File.directory?("/sys/module/#{directory}/parameters")
+          begin
+            Dir.foreach("/sys/module/#{directory}/parameters") do |param|
+              next if param == '.' or param == '..'
+              kmod[directory]['parameters'][param] = File.read("/sys/module/#{directory}/parameters/#{param}").chomp
+            end
+          rescue => e
+            Facter.warn(e)
           end
-        rescue => e
-          Facter.warn(e)
+        end
+
+        if File.directory?("/sys/module/#{directory}/holders")
+          begin
+            Dir.foreach("/sys/module/#{directory}/holders") do |used|
+              next if used == '.' or used == '..'
+              kmod[directory]['used_by'] << used
+            end
+          rescue => e
+            Facter.warn(e)
+          end
         end
       end
 
-      if File.directory?("/sys/module/#{directory}/holders")
-        begin
-          Dir.foreach("/sys/module/#{directory}/holders") do |used|
-            next if used == '.' or used == '..'
-            kmod[directory]['used_by'] << used
-          end
-        rescue => e
-          Facter.warn(e)
-        end
-      end
-
+      kmod
+    else
+      Facter.debug('/sys/module is not found. skipping.')
     end
-
-    kmod
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
File.exists? can't be used with confine. It should be used in actual
logics, otherwise fact gathering fails with the following error.
```
error while resolving custom facts in .../lib/facter/kmod.rb: expected argument to be a String, Symbol, or Hash
```

#### This Pull Request (PR) fixes the following issues
Fixes #74