### PR TITLE
Hide read error on params when you can't read them

### DIFF
--- a/lib/facter/kmod.rb
+++ b/lib/facter/kmod.rb
@@ -20,8 +20,12 @@ Facter.add(:kmods) do
             Dir.foreach("/sys/module/#{directory}/parameters") do |param|
               next if ['.', '..'].include?(param)
 
+              next unless File.readable?("/sys/module/#{directory}/parameters/#{param}")
+
               kmod[directory]['parameters'][param] = File.read("/sys/module/#{directory}/parameters/#{param}").chomp
             end
+          rescue Errno::EACCES => e
+            Facter.debug(e)
           rescue StandardError => e
             Facter.warn(e)
           end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This should keep from showing errors on params that are write only.

#### This Pull Request (PR) fixes the following issues
None listed
