### PR TITLE
Ignore kmod fact read errors

### DIFF
--- a/lib/facter/kmod.rb
+++ b/lib/facter/kmod.rb
@@ -16,30 +16,27 @@ Facter.add(:kmods) do
         }
 
         if File.directory?("/sys/module/#{directory}/parameters")
-          begin
-            Dir.foreach("/sys/module/#{directory}/parameters") do |param|
-              next if ['.', '..'].include?(param)
+          Dir.foreach("/sys/module/#{directory}/parameters") do |param|
+            next if ['.', '..'].include?(param)
 
-              next unless File.readable?("/sys/module/#{directory}/parameters/#{param}")
+            next unless File.readable?("/sys/module/#{directory}/parameters/#{param}")
 
+            begin
               kmod[directory]['parameters'][param] = File.read("/sys/module/#{directory}/parameters/#{param}").chomp
+            rescue StandardError
+              # some kernel parameters are write only
+              # even though they have the read bit set
+              # so just ignore read errors
+              nil
             end
-          rescue Errno::EACCES => e
-            Facter.debug(e)
-          rescue StandardError => e
-            Facter.warn(e)
           end
         end
 
         if File.directory?("/sys/module/#{directory}/holders")
-          begin
-            Dir.foreach("/sys/module/#{directory}/holders") do |used|
-              next if ['.', '..'].include?(used)
+          Dir.foreach("/sys/module/#{directory}/holders") do |used|
+            next if ['.', '..'].include?(used)
 
-              kmod[directory]['used_by'] << used
-            end
-          rescue StandardError => e
-            Facter.warn(e)
+            kmod[directory]['used_by'] << used
           end
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description
The more targeted `rescue` seems to have a few edges I didn't expect.  This PR just puts all the errors into the facter debug level.  This should let folks track them if needed, but hide the results for the various edges folks are encountering.

#### This Pull Request (PR) fixes the following issues
Fixes #79
