### PR TITLE
Fix kmod::alias example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Adds an alias to modprobe.conf, by default `/etc/modprobe.d/<name>.conf` is assu
 
 ```puppet
   kmod::alias { 'bond0':
-    aliasname => 'bonding',
+    source => 'bonding',
   }
 ```
 

--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -3,7 +3,7 @@
 # == Example
 #
 #     kmod::alias { 'bond0':
-#       alias => 'bonding',
+#       source => 'bonding',
 #     }
 #
 define kmod::alias (


### PR DESCRIPTION
The entry in README.md for kmod::alias has the following example:

```puppet
  kmod::alias { 'bond0':
    aliasname => 'bonding',
  }
```

It should read as follows:

```puppet
  kmod::alias { 'bond0':
    source => 'bonding',
  }
```

Fixes #84