### PR TITLE
Skip unreadable enable_nmi parameter

### DIFF
--- a/lib/facter/kmod.rb
+++ b/lib/facter/kmod.rb
@@ -20,6 +20,8 @@ Facter.add(:kmods) do
             Dir.foreach("/sys/module/#{directory}/parameters") do |param|
               next if ['.', '..'].include?(param)
 
+              next if ['enable_nmi'].include?(param)
+
               next unless File.readable?("/sys/module/#{directory}/parameters/#{param}")
 
               kmod[directory]['parameters'][param] = File.read("/sys/module/#{directory}/parameters/#{param}").chomp


### PR DESCRIPTION
#### Pull Request (PR) description
This PR creates an array of parameters to manually skip, including the `enable_nmi` that can't be read despite it having proper filesystem permissions.

#### This Pull Request (PR) fixes the following issues
Fixes #79