### PR TITLE
Replace egrep usage with grep -E

### DIFF
--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -27,7 +27,7 @@ define kmod::load (
 
       exec { "modprobe ${name}":
         path   => '/bin:/sbin:/usr/bin:/usr/sbin',
-        unless => "egrep -q '^${name} ' /proc/modules",
+        unless => "grep -qE '^${name} ' /proc/modules",
       }
     }
 
@@ -44,7 +44,7 @@ define kmod::load (
 
       exec { "modprobe -r ${name}":
         path   => '/bin:/sbin:/usr/bin:/usr/sbin',
-        onlyif => "egrep -q '^${name} ' /proc/modules",
+        onlyif => "grep -qE '^${name} ' /proc/modules",
       }
     }
 

--- a/spec/defines/kmod_load_spec.rb
+++ b/spec/defines/kmod_load_spec.rb
@@ -23,7 +23,7 @@ describe 'kmod::load', type: :define do
 
         it {
           is_expected.to contain_exec('modprobe foo').
-            with('unless' => "egrep -q '^foo ' /proc/modules")
+            with('unless' => "grep -qE '^foo ' /proc/modules")
         }
 
         context 'when on systemd' do
@@ -75,7 +75,7 @@ describe 'kmod::load', type: :define do
 
         it {
           is_expected.to contain_exec('modprobe -r foo').
-            with('onlyif' => "egrep -q '^foo ' /proc/modules")
+            with('onlyif' => "grep -qE '^foo ' /proc/modules")
         }
 
         context 'when on systemd' do


### PR DESCRIPTION
grep 3.8 deprecated support for egrep + fgrep, and now prints a warning on stderr:

````
egrep: warning: egrep is obsolescent; using grep -E
````