### PR TITLE
Drop legacy code for non-systemd systems

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -303,7 +303,6 @@ kmod::load { 'sha256': }
 The following parameters are available in the `kmod::load` defined type:
 
 * [`ensure`](#-kmod--load--ensure)
-* [`file`](#-kmod--load--file)
 
 ##### <a name="-kmod--load--ensure"></a>`ensure`
 
@@ -312,15 +311,6 @@ Data type: `Enum['present', 'absent']`
 State of the setting
 
 Default value: `'present'`
-
-##### <a name="-kmod--load--file"></a>`file`
-
-Data type: `Stdlib::Unixpath`
-
-Optionally, set the file where the stanza is written. Not
-used for systems running systemd.
-
-Default value: `'/etc/modules'`
 
 ### <a name="kmod--option"></a>`kmod::option`
 

--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -1,15 +1,11 @@
 # @summary Manage a kernel module in /etc/modules.
 #
 # @param ensure State of the setting
-# @param file
-#   Optionally, set the file where the stanza is written. Not
-#   used for systems running systemd.
 #
 # @example
 #   kmod::load { 'sha256': }
 define kmod::load (
   Enum['present', 'absent'] $ensure = 'present',
-  Stdlib::Unixpath          $file   = '/etc/modules',
 ) {
   include kmod
 
@@ -51,66 +47,11 @@ define kmod::load (
     default: { fail "${module_name}: unknown ensure value ${ensure}" }
   }
 
-  if $facts['service_provider'] == 'systemd' {
-    file { "/etc/modules-load.d/${name}.conf":
-      ensure  => $ensure,
-      mode    => $kmod::file_mode,
-      owner   => $kmod::owner,
-      group   => $kmod::group,
-      content => "# This file is managed by the puppet kmod module.\n${name}\n",
-    }
-  } else {
-    case $facts['os']['family'] {
-      'Debian': {
-        ensure_resource(
-          'file',
-          $file,
-          {
-            'ensure' => 'file',
-            'owner'  => $kmod::owner,
-            'group'  => $kmod::group,
-            'mode'   => $kmod::file_mode,
-          }
-        )
-        augeas { "Manage ${name} in ${file}":
-          incl    => $file,
-          lens    => 'Modules.lns',
-          changes => $changes,
-        }
-      }
-      'RedHat': {
-        file { "/etc/sysconfig/modules/${name}.modules":
-          ensure  => $ensure,
-          mode    => $kmod::exe_mode,
-          owner   => $kmod::owner,
-          group   => $kmod::group,
-          content => template('kmod/redhat.modprobe.erb'),
-        }
-      }
-      'Suse': {
-        $kernelfile = $file ? {
-          '/etc/modules' => '/etc/sysconfig/kernel',
-          default        => $file,
-        }
-        ensure_resource(
-          'file',
-          $kernelfile,
-          {
-            'ensure' => 'file',
-            'owner'  => $kmod::owner,
-            'group'  => $kmod::group,
-            'mode'   => $kmod::file_mode,
-          }
-        )
-        augeas { "sysconfig_kernel_MODULES_LOADED_ON_BOOT_${name}":
-          lens    => 'Shellvars_list.lns',
-          incl    => $kernelfile,
-          changes => $changes,
-        }
-      }
-      default: {
-        fail "${module_name}: Unknown OS family ${facts['os']['family']}"
-      }
-    }
+  file { "/etc/modules-load.d/${name}.conf":
+    ensure  => $ensure,
+    mode    => $kmod::file_mode,
+    owner   => $kmod::owner,
+    group   => $kmod::group,
+    content => "# This file is managed by the puppet kmod module.\n${name}\n",
   }
 }

--- a/spec/classes/kmod_spec.rb
+++ b/spec/classes/kmod_spec.rb
@@ -70,12 +70,7 @@ describe 'kmod', type: :class do
 
     context "on #{os} with hash parameters" do
       let(:facts) do
-        data = if facts[:os]['name'] == 'Archlinux'
-                 { augeasversion: '1.2.0', service_provider: 'systemd' }
-               else
-                 { augeasversion: '1.2.0' }
-               end
-        facts.merge(data)
+        facts.merge({ augeasversion: '1.2.0' })
       end
       let(:params) do
         {

--- a/spec/defines/kmod_load_spec.rb
+++ b/spec/defines/kmod_load_spec.rb
@@ -8,16 +8,11 @@ describe 'kmod::load', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-        data = if facts[:os]['name'] == 'Archlinux'
-                 { augeasversion: '1.2.0', service_provider: 'systemd' }
-               else
-                 { augeasversion: '1.2.0', service_provider: nil }
-               end
-        facts.merge(data)
+        facts.merge({ augeasversion: '1.2.0' })
       end
 
       context 'with ensure set to present' do
-        let(:params) { { ensure: 'present', file: '/foo/bar' } }
+        let(:params) { { ensure: 'present' } }
 
         it { is_expected.to contain_kmod__load('foo') }
 
@@ -27,10 +22,6 @@ describe 'kmod::load', type: :define do
         }
 
         context 'when on systemd' do
-          let(:facts) do
-            facts.merge(service_provider: 'systemd')
-          end
-
           it {
             is_expected.to contain_file('/etc/modules-load.d/foo.conf').
               with('ensure' => 'present',
@@ -38,38 +29,10 @@ describe 'kmod::load', type: :define do
                    'content' => "# This file is managed by the puppet kmod module.\nfoo\n")
           }
         end
-
-        context 'when not on systemd' do
-          it { is_expected.to compile.with_all_deps }
-
-          case facts[:osfamily]
-          when 'Debian'
-            it {
-              is_expected.to contain_augeas('Manage foo in /foo/bar').
-                with('incl' => '/foo/bar',
-                     'lens' => 'Modules.lns',
-                     'changes' => "clear 'foo'")
-            }
-          when 'Suse'
-            it {
-              is_expected.to contain_augeas('sysconfig_kernel_MODULES_LOADED_ON_BOOT_foo').
-                with('incl' => '/foo/bar',
-                     'lens' => 'Shellvars_list.lns',
-                     'changes' => "set MODULES_LOADED_ON_BOOT/value[.='foo'] 'foo'")
-            }
-          when 'RedHat'
-            it {
-              is_expected.to contain_file('/etc/sysconfig/modules/foo.modules').
-                with('ensure' => 'present',
-                     'mode' => '0755',
-                     'content' => %r{exec /sbin/modprobe foo > /dev/null 2>&1})
-            }
-          end
-        end
       end
 
       context 'with ensure set to absent' do
-        let(:params) { { ensure: 'absent', file: '/foo/bar' } }
+        let(:params) { { ensure: 'absent', } }
 
         it { is_expected.to contain_kmod__load('foo') }
 
@@ -79,10 +42,6 @@ describe 'kmod::load', type: :define do
         }
 
         context 'when on systemd' do
-          let(:facts) do
-            facts.merge(service_provider: 'systemd')
-          end
-
           it {
             is_expected.to contain_file('/etc/modules-load.d/foo.conf').
               with('ensure' => 'absent',
@@ -90,38 +49,10 @@ describe 'kmod::load', type: :define do
                    'content' => "# This file is managed by the puppet kmod module.\nfoo\n")
           }
         end
-
-        context 'when not on systemd' do
-          it { is_expected.to compile.with_all_deps }
-
-          case facts[:osfamily]
-          when 'Debian'
-            it {
-              is_expected.to contain_augeas('Manage foo in /foo/bar').
-                with('incl' => '/foo/bar',
-                     'lens' => 'Modules.lns',
-                     'changes' => "rm 'foo'")
-            }
-          when 'Suse'
-            it {
-              is_expected.to contain_augeas('sysconfig_kernel_MODULES_LOADED_ON_BOOT_foo').
-                with('incl' => '/foo/bar',
-                     'lens' => 'Shellvars_list.lns',
-                     'changes' => "rm MODULES_LOADED_ON_BOOT/value[.='foo']")
-            }
-          when 'RedHat'
-            it {
-              is_expected.to contain_file('/etc/sysconfig/modules/foo.modules').
-                with('ensure' => 'absent',
-                     'mode' => '0755',
-                     'content' => %r{exec /sbin/modprobe foo > /dev/null 2>&1})
-            }
-          end
-        end
       end
 
       context 'when file permissions are specified' do
-        let(:params) { { ensure: 'present', file: '/foo/bar' } }
+        let(:params) { { ensure: 'present', } }
         let(:pre_condition) do
           <<~END
             class { 'kmod':
@@ -136,29 +67,12 @@ describe 'kmod::load', type: :define do
         it { is_expected.to contain_kmod__load('foo') }
 
         it do
-          case facts[:osfamily]
-          when 'RedHat'
-            is_expected.to contain_file('/etc/sysconfig/modules/foo.modules').
-              with(
-                'owner' => 'adm',
-                'group' => 'sys',
-                'mode' => '0711'
-              )
-          when 'Archlinux'
-            is_expected.to contain_file('/etc/modules-load.d/foo.conf').
-              with(
-                'owner' => 'adm',
-                'group' => 'sys',
-                'mode' => '0600'
-              )
-          else
-            is_expected.to contain_file(params[:file]).
-              with(
-                'owner' => 'adm',
-                'group' => 'sys',
-                'mode' => '0600'
-              )
-          end
+          is_expected.to contain_file('/etc/modules-load.d/foo.conf').
+            with(
+              'owner' => 'adm',
+              'group' => 'sys',
+              'mode' => '0600'
+            )
         end
       end
     end


### PR DESCRIPTION
we only support linux versions with systemd, we can drop the legacy code.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
