### PR TITLE
Strip null bytes in kmods fact

### DIFF
--- a/lib/facter/kmod.rb
+++ b/lib/facter/kmod.rb
@@ -24,7 +24,7 @@ Facter.add(:kmods) do
             next unless File.readable?("/sys/module/#{directory}/parameters/#{param}")
 
             begin
-              kmod[directory]['parameters'][param] = File.read("/sys/module/#{directory}/parameters/#{param}").chomp
+              kmod[directory]['parameters'][param] = File.read("/sys/module/#{directory}/parameters/#{param}").chomp.delete("\u0000")
             rescue StandardError
               # some kernel parameters are write only
               # even though they have the read bit set


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Puppet won't allow facts containing null bytes. This will remove any null bytes from values within the `kmods` fact

#### This Pull Request (PR) fixes the following issues
Fixes #98
